### PR TITLE
Add sails v0.11.0 requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 > Integrates newrelic with your Sails application
 
 ## Install
+> **Note:** This library requires sails >= 0.11.0
 
 ```bash
 npm install sails-hook-newrelic


### PR DESCRIPTION
This PR updates the readme to let users know that the minimum supported version of sails for this library is v0.11. 
