### PR TITLE
Allow hook to work without disrupting `sails lift`

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(sails) {
       sails.newrelic = global.newrelic;
       delete global.newrelic;
       sails.on('router:route', function(route) {
-        if (route.req.options && route.req.options.controller) {
+        if (sails.newRelic && route.req.options && route.req.options.controller) {
           return sails.newrelic.setControllerName(route.req.options.controller, route.req.options.action);
         }
       });


### PR DESCRIPTION
The hook works great on environments that use `node app.js` to start the application, but causes breaking errors when using `sails lift`. I'm seeing this when developing locally vs on production.

Adding this simple check for the existence of the `sails.newRelic` object will prevent errors when using `sails.lift`.
