### PR TITLE
modify register.js to handle multiple environment configurations

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,12 +1,30 @@
 'use strict';
 
 var path = require('path');
-var config = require(path.resolve('config/newrelic')).newrelic;
+var env = process.env.NODE_ENV;
+if(!env){
+  env = 'development';
+}
+var configFile = 'config/env/' + env + '/newrelic';
+var config = false;
 
-(function() {
-  global.newrelic = require('newrelic-config')
-  .name(config.app_name)
-  .key(config.license_key)
-  .log(null, config.logging.level, config.logging.rules.ignore.join(','))
-  .profile();
-}).call(this);
+try {
+
+  config = require(path.resolve(configFile)).newrelic;
+
+} catch (e) {
+  /*
+  supress exception if file not found
+  otherwise sails won't load
+  */
+}
+
+if(config){
+  (function() {
+    global.newrelic = require('newrelic-config')
+    .name(config.app_name)
+    .key(config.license_key)
+    .log(null, config.logging.level, config.logging.rules.ignore.join(','))
+    .profile();
+  }).call(this);
+}


### PR DESCRIPTION
Rather than having a newrelic.js in the root of config folder, place it in the relevant environment folder which is represented by environment variable process.env.NODE_ENV 

Wrap in a try catch so that if the file doesn't exist, then fails gracefully and doesn't load newrelic. This is helpful if you don't want to run newrelic in say, your dev environment

eg. you might have:
config/env/production/newrelic.js
config/env/staging/newrelic.js
but no file in config/env/development
